### PR TITLE
Issue 6 mark all read functionality as props

### DIFF
--- a/NotifyMe.js
+++ b/NotifyMe.js
@@ -164,7 +164,7 @@ const NotifyMe = props => {
                         <Popover.Title as="h3">{heading}</Popover.Title>
                         <Popover.Content style={{ padding: '3px 3px' }}>
                             {showCount && <div>
-                                <Button variant="link" onClick={markAsRead}>
+                                <Button variant="link" onClick={props.markAsRead || markAsRead}>
                                     <BookOpen size={24} />
                                     Mark all as read
                                 </Button>

--- a/NotifyMe.js
+++ b/NotifyMe.js
@@ -164,7 +164,7 @@ const NotifyMe = props => {
                         <Popover.Title as="h3">{heading}</Popover.Title>
                         <Popover.Content style={{ padding: '3px 3px' }}>
                             {showCount && <div>
-                                <Button variant="link" onClick={props.markAsRead || markAsRead}>
+                                <Button variant="link" onClick={props.markAsReadFn || markAsRead}>
                                     <BookOpen size={24} />
                                     Mark all as read
                                 </Button>
@@ -209,7 +209,8 @@ NotifyMe.prototype = {
     size: PropTypes.string,
     heading: PropTypes.string,
     multiLineSplitter: PropTypes.string,
-    showDate: PropTypes.bool
+    showDate: PropTypes.bool,
+    markAsReadFn: PropTypes.func
 }
 
 export default NotifyMe;

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Here is an example usage,
   showDate={true}
   size={64}
   color="yellow"
+  markAsRead={() => markAsReadFunc()}
 />
 ```
 
@@ -170,6 +171,18 @@ Here is an example usage,
     <td> It stores the last read message key in localstorage of the browser.</td>
     <td> No </td>
     <td> Any string of your choice as a key. Default value is, <b>notification_timeline_storage_id</b></td>
+  </tr>
+  
+  <tr>
+    <td> markAsRead </td>
+    <td> User can control the functionality of "Mark All As Read" by passing the function as prop as below
+    markAsRead = {() => yourOwnFunction()}
+    </td>
+    <td> No </td>
+    <td> Now "Mark All As Read" can be controlled by passing you own function as prop. Default functionality is, 
+    1. We will clear the notification count.
+    2. Update the reactLocalStore with the latest notification key.
+    3. We will set the readIndex to 0 - which is used to highlight the unread notifications.</td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -180,9 +180,12 @@ Here is an example usage,
     </td>
     <td> No </td>
     <td> Now "Mark All As Read" can be controlled by passing you own function as prop. Default functionality is, 
-    1. We will clear the notification count.
-    2. Update the reactLocalStore with the latest notification key.
-    3. We will set the readIndex to 0 - which is used to highlight the unread notifications.</td>
+      <ul>
+        <li> We will clear the notification count.</li>
+        <li> Update the reactLocalStore with the latest notification key.</li>
+        <li> We will set the readIndex to 0 - which is used to highlight the unread notifications.</li>
+      </ul>
+   </td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Here is an example usage,
   showDate={true}
   size={64}
   color="yellow"
-  markAsRead={() => markAsReadFunc()}
+  markAsReadFn={() => yourOwnFunctionHandler()}
 />
 ```
 
@@ -176,10 +176,10 @@ Here is an example usage,
   <tr>
     <td> markAsRead </td>
     <td> User can control the functionality of "Mark All As Read" by passing the function as prop as below
-    markAsRead = {() => yourOwnFunction()}
+    markAsReadFn = {() => yourOwnFunctionHandler()}
     </td>
     <td> No </td>
-    <td> Now "Mark All As Read" can be controlled by passing you own function as prop. Default functionality is, 
+    <td> Now "Mark All As Read" can be controlled by passing your own function as prop. Default functionality is, 
       <ul>
         <li> We will clear the notification count.</li>
         <li> Update the reactLocalStore with the latest notification key.</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-notification-timeline",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "React Component to notify you and keep track of it as a timeline",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Issue : [https://github.com/atapas/notifyme/issues/6](url)

Now users can control the functionality of the "Mark All As Read" button bypassing their own function as a prop.