### PR TITLE
PropType Typo Fixed and New Prop Added as theme

### DIFF
--- a/NotifyMe.js
+++ b/NotifyMe.js
@@ -35,7 +35,7 @@ const NotifyMe = props => {
     const sortedByKey = props.sortedByKey;
     const heading = props.heading || 'Notifications';
     const bellSize = props.size || 32;
-    const bellColor = props.color || '#FFFFFF';
+    const theme = props.theme || {color:'yellow',backgroundColor:'#282828'};
     const multiLineSplitter = props.multiLineSplitter || '\n';
     const showDate = props.showDate || false;
     const Icon = props.icon || Bell;
@@ -144,10 +144,11 @@ const NotifyMe = props => {
     return (
         <>
             <div className="notification-container">
-                <div className={showCount ? 'notification notify show-count' : 'notification notify'}
+                <div className={`notification ${showCount ? 'notify show-count' : 'notify'}`}
+                    style={{backgroundColor:theme.backgroundColor}}
                     data-count={messageCount}
                     onClick={event => handleClick(event)}>
-                    <Icon color={bellColor} size={bellSize} />
+                    <Icon color={theme.color} size={bellSize} />
                 </div>
             </div>
 
@@ -200,13 +201,16 @@ const NotifyMe = props => {
     )
 };
 
-NotifyMe.prototype = {
+NotifyMe.propTypes  = {
     storageKey: PropTypes.string,
     notific_key: PropTypes.string.isRequired,
     data: PropTypes.array.isRequired,
     notific_value: PropTypes.string.isRequired,
     sortedByKey: PropTypes.bool,
-    color: PropTypes.string,
+    theme: PropTypes.shape({
+        color: PropTypes.string,
+        backgroundColor: PropTypes.string
+    }),
     size: PropTypes.string,
     heading: PropTypes.string,
     multiLineSplitter: PropTypes.string,

--- a/README.md
+++ b/README.md
@@ -82,10 +82,22 @@ Here is an example usage,
   </tr>
 
   <tr>
-    <td> color </td>
-    <td> Color of the notification bell. Pass a color to customize it.</td>
+    <td> theme </td>
+    <td> customizing the background and foreground of the Notification and its icon
+    </td>
     <td> No </td>
-    <td> Color in Hexacode, rgb or string name. Default value is, <b>#FFFFFF</b></td>
+    <td>
+      color and background color can be either in HexaCode,rgb or string name. Default is
+      
+
+   ```js
+      {
+        color:"yellow",
+        backgroundColor:"#282828"
+      }
+   ```
+   
+   </td>
   </tr>
   
   <tr>


### PR DESCRIPTION
The typo that was in the PropTypes is fixed and a new prop is added as theme, which can use to configure the background and foreground of the Notification Component.
![screenshot3](https://user-images.githubusercontent.com/55610818/135798081-0277c5bc-15b1-42fe-b22a-296a49de8188.PNG)

Above code resulted follow,

![screenshot2](https://user-images.githubusercontent.com/55610818/135798055-5dbd22c6-e798-4832-a0ec-2a6f51a989ef.PNG)


